### PR TITLE
대회 리스트가 화면을 벗어나지 않도록 CSS 수정

### DIFF
--- a/inject.css
+++ b/inject.css
@@ -6,7 +6,7 @@
   border-radius: 10px;
   background-color: #eee;
   padding: 5px 15px;
-  margin: 0 3px;
+  margin: 3px;
   text-align: center;
 }
 
@@ -17,5 +17,6 @@
 div.kipa-tab-bar {
   display: flex;
   flex-direction: row;
-  margin: 0 0 5px 0;
+  margin: 0 0 2px 0;
+  flex-wrap: wrap;
 }


### PR DESCRIPTION
이 PR은:

* 대회 목록이 너무 길어질 경우 여러 줄로 보여줍니다.
  * 따라서, #1​을 해결합니다.

대회가 너무 많아지면 화면을 덮을 수도 있기에 이 조치는 임시 조치였으면 좋겠지만, 이를 더 좋게 해결할 마땅한 아이디어는 일단 지금은 없습니다.